### PR TITLE
Resolves cached item not sending original headers

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,10 +50,10 @@ var _outputCache = {
 
     helpers: {
 
-        setHeadersOnCacheItem: function onSetHeaders(req, res, cacheItem, headers) {
+        setHeadersOnCacheItem: function onSetHeaders(req, res, cacheItem) {
 
-            cacheItem.headers = headers;
-            var responseCacheHeader = headers['cache-control'];
+            cacheItem.headers = JSON.parse(JSON.stringify(res._headers));
+            var responseCacheHeader = res._headers['cache-control'];
 
             if (!responseCacheHeader) {
                 var staleWhileRevalidateInfo = _options.staleWhileRevalidate ? ', stale-while-revalidate=' + _options.staleWhileRevalidate : '';
@@ -125,7 +125,7 @@ var _outputCache = {
 
             res.send = function onOverrideSend(a, b) {
 
-                var responseToCache = _outputCache.helpers.setHeadersOnCacheItem(req, res, {}, resHeadersRaw);
+                var responseToCache = _outputCache.helpers.setHeadersOnCacheItem(req, res, {});
 
                 if (!_options.noHeaders) {
                     res.set({ 'X-Output-Cache': 'ms' });


### PR DESCRIPTION
Found an issue with the cached item not sending the correct 'content-type' header back which results in express changing the content-type to the default (html)